### PR TITLE
목표를 등록하고, 목표리스트에 리스트 가져오기

### DIFF
--- a/src/pages/MissionList.jsx
+++ b/src/pages/MissionList.jsx
@@ -1,9 +1,21 @@
 import { Link } from 'react-router-dom';
 
 export default function MissionList() {
+  const missionItems = JSON.parse(localStorage.getItem('newData'));
+
   return (
     <div>
       목표 리스트
+      <br />
+      {missionItems ? (
+        <div>
+          <p>목표 : {missionItems.title}</p>
+          <p>포부한마디 : {missionItems.saying}</p>
+          <p>인증 : 인증횟수 /  {missionItems.count}</p>
+        </div>
+      ) : (
+        '새로운 목표를 등록해주세요.'
+      )}
       <Link to="/writemission">목표 등록하기</Link>
     </div>
   );

--- a/src/pages/MissionWrite.jsx
+++ b/src/pages/MissionWrite.jsx
@@ -33,15 +33,18 @@ export default function MissionWrite() {
       <form onSubmit={handleSubmit(onSubmit, onError)}>
         <div>
           <label>목표</label>
-          <input type="text" {...register('title')} />
+          <input type="text" {...register('title', { required: true })} />
+          {errors.title && <span>목표를 입력해주세요.</span>}
         </div>
         <div>
           <label>포부한마디</label>
-          <textarea type="text" {...register('saying')} />
+          <textarea type="text" {...register('saying', { required: true })} />
+          {errors.saying && <span>포부 한마디를 입력해주세요.</span>}
         </div>
         <div>
           <label>인증할 횟수</label>
-          <input type="num" {...register('count')} />
+          <input type="num" {...register('count', { required: true })} />
+          {errors.count && <span>인증할 횟수를 입력해주세요.</span>}
         </div>
         <input type="submit" />
       </form>

--- a/src/pages/MissionWrite.jsx
+++ b/src/pages/MissionWrite.jsx
@@ -1,15 +1,29 @@
 import { useForm } from 'react-hook-form';
 
+import { useNavigate } from 'react-router-dom';
+
 export default function MissionWrite() {
+  const navigate = useNavigate();
+
   const {
     register,
     handleSubmit,
     onError,
     formState: { errors },
-  } = useForm();
+  } = useForm({
+    mode: 'onChange',
+    defaultValues: {},
+  });
 
   const onSubmit = (data) => {
-    console.log(data);
+    const missionItems = JSON.parse(localStorage.getItem('newData'));
+
+    if (missionItems) {
+      alert('등록된 목표가 있습니다.');
+    } else {
+      localStorage.setItem('newData', JSON.stringify(data));
+    }
+    navigate('/');
   };
 
   return (
@@ -18,14 +32,17 @@ export default function MissionWrite() {
 
       <form onSubmit={handleSubmit(onSubmit, onError)}>
         <div>
-          <label>목표이름</label>
+          <label>목표</label>
           <input type="text" {...register('title')} />
         </div>
         <div>
           <label>포부한마디</label>
-          <textarea type="text" {...register('hopes')} />
+          <textarea type="text" {...register('saying')} />
         </div>
-
+        <div>
+          <label>인증할 횟수</label>
+          <input type="num" {...register('count')} />
+        </div>
         <input type="submit" />
       </form>
     </div>


### PR DESCRIPTION
### 목표를 등록하고, 목표리스트에 리스트 가져오기

- `MissionWrite.jsx` : 목표 등록 화면
   - 목표, 포부 한마디, 인증할 횟수를 입력 후 제출하면 localStorage에 정보를 저장합니다. 
   - 입력하는 정보는 모두 필수값 체크를 합니다.
   - localStorage에 저장된 목표가 있는 경우에는 등록된 목표가 있습니다 를 표시합니다. ( 👉🏻 다음주에 여러개의 목표를 등록할 수 있도록 변경할 예정 )
 
- `MissionList.jsx` : 목표 리스트 화면
   - localStorage에 저장된 목표가 없는 경우 : '새로운 목표를 등록해주세요.'를 표시합니다.
   - localStorage에 저장된 목표가 있는 경우 : 저장된 목표 내용을 가져와서 리스트에 노출시킵니다.

- - - 

회사동료분이 프로젝트가 재밌어 보인다며 API를 생성해주시기로 했습니다😃
생성되면 localStorage로 저장하는 부분을 수정하려고 합니다!
