### PR TITLE
Emotion CSS - Global Style, theme/ reset스타일 추가 적용

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,18 +1,24 @@
 import { Route, Routes } from 'react-router-dom';
 
+import { ThemeProvider } from '@emotion/react';
+import { theme } from './shared/styles/theme';
+import GlobalStyle from './shared/styles/GlobalStyles';
+
 import HeaderContainer from './components/HeaderContainer';
 import MissionList from './pages/MissionList';
 import MissionWrite from './pages/MissionWrite';
 
 export default function App() {
   return (
-    <div>
+    <ThemeProvider theme={theme}>
+      <GlobalStyle />
+
       <HeaderContainer />
 
       <Routes>
         <Route path="/" element={<MissionList />} />
         <Route path="/writemission" element={<MissionWrite />} />
       </Routes>
-    </div>
+    </ThemeProvider>
   );
 }

--- a/src/shared/styles/GlobalStyles.jsx
+++ b/src/shared/styles/GlobalStyles.jsx
@@ -1,0 +1,25 @@
+import { useTheme, Global, css } from '@emotion/react';
+
+import reset from './reset';
+
+export default function GlobalStyle() {
+  const theme = useTheme();
+
+  return (
+    <Global
+      styles={css`
+        @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+        ${reset}
+        html {
+        }
+        body {
+          position: relative;
+          min-width: 320px;
+          font-family: ${theme.fonts.pretendard};
+          color: ${theme.colors.font};
+          overflow-x: hidden;
+        }
+      `}
+    />
+  );
+}

--- a/src/shared/styles/reset.jsx
+++ b/src/shared/styles/reset.jsx
@@ -1,0 +1,335 @@
+import { css } from '@emotion/react';
+
+const reset = css`
+  html,
+  body,
+  div,
+  span,
+  applet,
+  object,
+  iframe,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  pre,
+  a,
+  abbr,
+  acronym,
+  address,
+  big,
+  cite,
+  code,
+  del,
+  dfn,
+  em,
+  img,
+  ins,
+  kbd,
+  q,
+  s,
+  samp,
+  small,
+  strike,
+  strong,
+  sub,
+  sup,
+  tt,
+  b,
+  u,
+  i,
+  center,
+  dl,
+  dt,
+  dd,
+  ol,
+  ul,
+  li,
+  fieldset,
+  form,
+  label,
+  legend,
+  caption,
+  article,
+  aside,
+  canvas,
+  details,
+  embed,
+  figure,
+  figcaption,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  output,
+  ruby,
+  section,
+  summary,
+  time,
+  mark,
+  audio,
+  video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+    word-break: keep-all;
+  }
+  html {
+    line-height: 1.15;
+    -ms-text-size-adjust: 100%;
+    -webkit-text-size-adjust: 100%;
+  }
+  article,
+  aside,
+  footer,
+  header,
+  nav,
+  section {
+    display: block;
+  }
+  figcaption,
+  figure,
+  main {
+    display: block;
+  }
+  hr {
+    box-sizing: content-box;
+    height: 0;
+    overflow: visible;
+  }
+  pre {
+    font-family: monospace, monospace;
+    font-size: 1em;
+  }
+  a {
+    background-color: transparent;
+    -webkit-text-decoration-skip: objects;
+  }
+  ol,
+  ul {
+    list-style: none;
+  }
+  abbr[title] {
+    border-bottom: none;
+    text-decoration: underline;
+    text-decoration: underline dotted;
+  }
+  b,
+  strong {
+    font-weight: inherit;
+  }
+  b,
+  strong {
+    font-weight: bolder;
+  }
+  code,
+  kbd,
+  samp {
+    font-family: monospace, monospace;
+    font-size: 1em;
+  }
+  dfn {
+    font-style: italic;
+  }
+  mark {
+    background-color: #ff0;
+    color: #000;
+  }
+  sub,
+  sup {
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+  sub {
+    bottom: -0.25em;
+  }
+  sup {
+    top: -0.5em;
+  }
+  audio,
+  video {
+    display: inline-block;
+  }
+  audio:not([controls]) {
+    display: none;
+    height: 0;
+  }
+  svg:not(:root) {
+    overflow: hidden;
+  }
+  input,
+  textarea {
+    -webkit-appearance: none;
+    -webkit-border-radius: 0;
+  }
+  .cke_dialog_open input,
+  .cke_dialog_open textarea {
+    -webkit-appearance: auto;
+  }
+  input:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0 30px #fff inset;
+    -webkit-text-fill-color: #000;
+  }
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus,
+  input:-webkit-autofill:active {
+    transition: background-color 5000s ease-in-out 0s;
+  }
+  select {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    border-radius: 0;
+  }
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    margin: 0;
+    padding: 0;
+  }
+  button,
+  input {
+    overflow: visible;
+    border-radius: 0;
+  }
+  button,
+  select {
+    text-transform: none;
+  }
+  button,
+  html [type='button'],
+  [type='reset'],
+  [type='submit'] {
+    -webkit-appearance: button;
+  }
+  button::-moz-focus-inner,
+  [type='button']::-moz-focus-inner,
+  [type='reset']::-moz-focus-inner,
+  [type='submit']::-moz-focus-inner {
+    border-style: none;
+    padding: 0;
+  }
+  button:-moz-focusring,
+  [type='button']:-moz-focusring,
+  [type='reset']:-moz-focusring,
+  [type='submit']:-moz-focusring {
+    outline: 1px dotted ButtonText;
+  }
+  legend {
+    box-sizing: border-box;
+    color: inherit;
+    display: table;
+    max-width: 100%;
+    padding: 0;
+    white-space: normal;
+  }
+  progress {
+    display: inline-block;
+    vertical-align: baseline;
+  }
+  textarea {
+    overflow: auto;
+    border-radius: 0;
+  }
+  input::-ms-clear {
+    display: none;
+  }
+  input[type='password']::-ms-reveal {
+    display: none;
+    width: 0;
+    height: 0;
+  }
+  [type='checkbox'],
+  [type='radio'] {
+    box-sizing: border-box;
+    padding: 0;
+  }
+  [type='number']::-webkit-inner-spin-button,
+  [type='number']::-webkit-outer-spin-button {
+    height: auto;
+  }
+  [type='search'] {
+    -webkit-appearance: textfield;
+    outline-offset: -2px;
+  }
+  [type='search']::-webkit-search-cancel-button,
+  [type='search']::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+  ::-webkit-file-upload-button {
+    -webkit-appearance: button;
+    font: inherit;
+  }
+  details,
+  menu {
+    display: block;
+  }
+  summary {
+    display: list-item;
+  }
+  canvas {
+    display: inline-block;
+  }
+  template {
+    display: none;
+  }
+  [hidden] {
+    display: none;
+  }
+  table:not([cellspacing]) {
+    border-collapse: collapse;
+    border-spacing: 0;
+    word-break: keep-all;
+  }
+  a,
+  a:hover,
+  a:focus {
+    color: inherit;
+    text-decoration: none;
+  }
+  * {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+  img {
+    display: inline-block;
+    max-width: 100%;
+    height: auto;
+    border-style: none;
+  }
+  input,
+  button,
+  select,
+  textarea {
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    outline: none;
+  }
+  .cke_screen_reader_only {
+    height: 0 !important;
+  }
+  button {
+    background-color: transparent;
+    border: none;
+    border-radius: 0;
+    outline: none;
+  }
+  select::-ms-expand {
+    display: none;
+  }
+`;
+
+export default reset;

--- a/src/shared/styles/theme.js
+++ b/src/shared/styles/theme.js
@@ -1,0 +1,37 @@
+const fonts = {
+  pretendard: 'Pretendard, sans-serif',
+  dotum: '"Dotum", sans-serif',
+};
+
+const colors = {
+  font: '#000',
+  point: '#0389fd',
+  border: '#ddd',
+  valid: '#ff000a',
+};
+
+const size = {
+  sm: '544px',
+  md: '768px',
+  lg: '992px',
+  xl: '1200px',
+};
+
+const mq = {
+  sm: `@media (min-width: ${size.sm})`,
+  md: `@media (min-width: ${size.md})`,
+  lg: `@media (min-width: ${size.lg})`,
+  xl: `@media (min-width: ${size.xl})`,
+};
+
+const gutter = {
+  mobile: '15px',
+  pc: '100px',
+};
+
+export const theme = {
+  fonts,
+  colors,
+  mq,
+  gutter,
+};


### PR DESCRIPTION
* Emotion의 Global Style, theme를 추가했다.
`App.jsx`파일에 `ThemeProvider`를 사용하여 스타일을 적용하였다.   
* Global style에 추가한 내용
  - reset스타일
  - 폰트 pretendard 적용
  - html, body태그에 폰트, 컬러 등의 기본 스타일 적용